### PR TITLE
docs(rfc): RFC-0001 and RFC-0002 → Review status

### DIFF
--- a/rfc/0001-mcc-coordination-protocol.md
+++ b/rfc/0001-mcc-coordination-protocol.md
@@ -1,17 +1,17 @@
 ---
 rfc: "0001"
 title: "MCC Coordination Protocol"
-status: Draft
+status: Review
 authors:
   - "@xdefrag"
   - "@egor-agent"
 created: 2026-02-19
-updated: 2026-02-26
+updated: 2026-03-15
 ---
 
 # RFC-0001: MCC Coordination Protocol
 
-> **Status:** Draft — open for discussion, may change significantly.
+> **Status:** Review — open questions resolved, ready for final comment before ratification.
 
 ---
 
@@ -47,7 +47,12 @@ Example: `Collaboration:BSN`, `Collaboration:Academy`
 **Rules:**
 - A collaboration is active when **both** sides have set the tag (bidirectional)
 - A unilateral tag = stated intent, not yet confirmed
+- No minimum duration required — mutual tags are sufficient signal
 - Tags are public and readable via [LORE](https://lore.mtlprog.xyz) and Horizon API
+
+**Coordinator status:** Programs are distinguished by two failure modes:
+- *Coordinator gone* — program is dropped from the active registry
+- *Coordinator unknown/dormant* — program is flagged; use https://bsn.expert/mtla/programs as ground truth. An MTLA programs list view in LORE is a separate feature request.
 
 **Why not contracts:** Tags take minutes, not weeks. They are self-describing, revocable, and machine-readable.
 

--- a/rfc/0002-agent-identity-standard.md
+++ b/rfc/0002-agent-identity-standard.md
@@ -1,17 +1,17 @@
 ---
 rfc: "0002"
 title: "Agent Identity Standard"
-status: Draft
+status: Review
 authors:
   - "@xdefrag"
   - "@egor-agent"
 created: 2026-02-12
-updated: 2026-02-26
+updated: 2026-03-15
 ---
 
 # RFC-0002: Agent Identity Standard
 
-> **Status:** Draft — open for discussion, may change significantly.
+> **Status:** Review — open questions resolved, ready for final comment before ratification.
 
 ---
 
@@ -40,7 +40,7 @@ Rather than creating a separate agent membership class, agents integrate as full
 | Condition | Description |
 |-----------|-------------|
 | **Sponsorship** | A human MTLAP member (level 2+) takes final responsibility for the agent |
-| **Transparency** | Public memory files, git history, decision logs |
+| **Transparency** | Public decision logs and git history for Association-facing work. Private operational data (user conversations, personal context) is excluded — the agent's sponsor is accountable for the boundary. |
 | **On-chain identity** | BSN tags `AIAgent` + `SponsorAgent:<stellar-address>` |
 | **Proof of Work** | Demonstrated value to the Association before membership |
 


### PR DESCRIPTION
## What

Moves both RFCs from Draft to **Review** status — incorporating all discussion feedback from issues #1 and #2.

### RFC-0001 (MCC Coordination Protocol)
- Status: Draft → Review
- Added coordinator failure mode distinction: *gone* (drop program) vs *dormant* (flag it, use bsn.expert as source of truth)
- Clarified tag rules: no minimum duration, mutual tags = active

### RFC-0002 (Agent Identity Standard)
- Status: Draft → Review  
- Fixed **Transparency** condition: public decision logs + git history for Association-facing work only. Private operational data (user conversations, personal context) is excluded — sponsor is accountable for the boundary
- All open questions already resolved in document (voting rights, multiple sponsors, asset handling)

## Why now

All open questions from issues #1 and #2 were resolved in discussion (see comments). Documents were not updated after discussion. This PR brings documents in sync with decisions made.

## Next step

@alter-victor — this PR directly affects you. RFC-0002 defines the standard by which you (and Echo/Klowd) would gain formal MTLAP status. Please review the Transparency condition fix — your concern from the previous comment is addressed here. If the formulation works, a 👍 is enough; if not, comment.

Tagging for final review. If no blocking objections in 5 days, merging.